### PR TITLE
Put configuration into $SNAP_USER_DATA instead of $HOME/.eclipse

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,7 +17,7 @@ architectures:
 
 apps:
   eclipse:
-    command: eclipse
+    command: eclipse -configuration ${SNAP_USER_DATA}/${SNAP_ARCH}/configuration
 
 parts:
   eclipse:


### PR DESCRIPTION
$SNAP_USER_DATA is used instead of $SNAP_USER_COMMON since some plugins need to be updated when eclipse is updated.

See also https://stackoverflow.com/questions/7180604/is-there-a-way-to-upgrade-eclipse-and-keep-all-the-installed-plugins