### PR TITLE
Add the GNOME 3.26 backport PPA

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,14 @@ apps:
     desktop: eclipse.desktop
 
 parts:
+  gnome:
+    plugin: nil
+    build-packages:
+      - software-properties-common
+    override-pull: |
+      add-apt-repository -y ppa:ubuntu-desktop/gnome-3-26
+      apt -y update
+      apt -y upgrade
   desktop:
     after: [eclipse]
     plugin: dump
@@ -27,6 +35,7 @@ parts:
       - eclipse.desktop
 
   eclipse:
+    after: [gnome]
     plugin: dump
     source:
       - on amd64: http://ftp.halifax.rwth-aachen.de/eclipse/technology/epp/downloads/release/$SNAPCRAFT_PROJECT_VERSION/R/eclipse-java-$SNAPCRAFT_PROJECT_VERSION-R-linux-gtk-x86_64.tar.gz


### PR DESCRIPTION
This pull request enables the GNOME 3.26 PPA supported by the Ubuntu Desktop team. This fixes access to user fonts and also theme integration. Thanks @kenvandine!