### PR TITLE
Eclipse 2021-09 with Ubuntu core20 base

### DIFF
--- a/snap/local/wrappers/eclipse
+++ b/snap/local/wrappers/eclipse
@@ -1,0 +1,2 @@
+#!/bin/bash
+/snap/eclipse/current/eclipse -configuration ${SNAP_USER_DATA}/${SNAP_ARCH}/configuration

--- a/snap/local/wrappers/eclipse
+++ b/snap/local/wrappers/eclipse
@@ -1,2 +1,2 @@
 #!/bin/bash
-/snap/eclipse/current/eclipse -configuration ${SNAP_USER_DATA}/${SNAP_ARCH}/configuration
+exec $SNAP/eclipse -configuration ${SNAP_USER_DATA}/${SNAP_ARCH}/configuration

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,7 +38,7 @@ parts:
     build-packages:
       - patchelf
     stage-packages:
-      - libffi-dev
+      - libffi7
       - libfreetype6
       - libpng16-16
       - libgdk-pixbuf2.0-0
@@ -51,4 +51,4 @@ parts:
     plugin: dump
     source: snap/local/wrappers
     organize:
-      "eclipse": bin/eclipse-wrapper
+      eclipse: bin/eclipse-wrapper

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: eclipse
-base: core18
+base: core20
 
-version: '2020-09'
+version: '2021-09'
 summary: Extensible Tool Platform and Java IDE
 description:
   Eclipse provides IDEs and platforms for nearly every language and architecture.
@@ -17,18 +17,17 @@ architectures:
 
 apps:
   eclipse:
-    command: eclipse -configuration ${SNAP_USER_DATA}/${SNAP_ARCH}/configuration
+    command: bin/eclipse-wrapper
 
 parts:
   eclipse:
     plugin: dump
     source: http://ftp.halifax.rwth-aachen.de/eclipse/technology/epp/downloads/release/$SNAPCRAFT_PROJECT_VERSION/R/eclipse-java-$SNAPCRAFT_PROJECT_VERSION-R-linux-gtk-x86_64.tar.gz
-    source-checksum: "sha512/38b063a4df5a0ae6d22f82fb1c64281e462ef8b4de6e4cc970d47e89575c447376550ebc8063b8bcf2c6532ac7a276fe9d4c79f140846357c4218899f9d93bf3"
+    source-checksum: "sha512/1baeed0f32ea23eed2c1166ab6b92b086f181a030c9a4e59bf424515c558bf1c57c5f6ce077c2f94c12644eb8224f6034b5d724d726636454428c12459f2028f"
     override-build: |
       snapcraftctl build
       # Add these missing libraries to DT_NEEDED
       patchelf \
-        --add-needed libffi.so.6 \
         --add-needed libgdk_pixbuf-2.0.so.0 \
         --add-needed libgio-2.0.so.0 \
         --add-needed libglib-2.0.so.0 \
@@ -39,7 +38,17 @@ parts:
     build-packages:
       - patchelf
     stage-packages:
-      - libffi6
+      - libffi-dev
+      - libfreetype6
+      - libpng16-16
       - libgdk-pixbuf2.0-0
-      - libglib2.0-0
       - libsecret-1-0
+      - libasound2
+      - libxi6
+      - libxrender1
+      - libxtst6
+  wrappers:
+    plugin: dump
+    source: snap/local/wrappers
+    organize:
+      "eclipse": bin/eclipse-wrapper


### PR DESCRIPTION
Wanted to bring Eclipse snap up to date with the current release. This PR has quite a few more changes than previous PRs by other developers so I'll explain each.

I couldn't get Eclipse 2021-09 to run with the Ubuntu core18 base. It seems there's quite a few dependency changes (surprisingly). Snapcraft complained about several missing dependencies so I added them to stage-packages but it still wouldn't run properly on core18 base, it would just immediately crash.

I suspected that it might work OK with core20 and it did. However the newer version of snapcraft in that base doesn't like the app command format (which previously generated a warning, now generates an error). To resolve this I have added a launch wrapper bash script to launch Eclipse in the same way as previously done in the app command, this launch wrapper is added as a second part in the snap.

It doesn't appear that libglib2 is needed any more, but several new dependencies were required. I'd appreciate some assistance in determining if we really need to include these dependencies but I was unable to get it to work without doing so. Any advice gratefully received.

I tested the bare Eclipse binary on Ubuntu 18.04 and it runs OK so it's a bit odd that it doesn't build against the core18 base. If anyone has any insights that can resolve that, I'll happily prepare an alternative PR with the core18 base. Otherwise, I hope this is helpful in getting an up-to-date Eclipse available via snap.